### PR TITLE
remove webpack and sass dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,14 +69,13 @@
   },
   "scripts": {
     "compile": "./node_modules/.bin/babel -d ./lib ./src",
-    "build": "cross-env NODE_ENV=production npm run compile && npm run sass",
+    "build": "cross-env NODE_ENV=production npm run compile",
     "clean": "rimraf ./lib",
     "lint": "eslint src test",
     "patch": "bumped release patch",
     "prebuild": "npm run clean",
     "prepublish": "npm run build",
     "release": "bumped release",
-    "sass": "cpx './src/**/*.scss' ./lib",
     "start": "cross-env NODE_ENV=development UV_THREADPOOL_SIZE=100 node ./server",
     "test": "cross-env NODE_ENV=test karma start",
     "test:watch": "cross-env NODE_ENV=test karma start --no-single-run"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "babel-preset-react-hmre": "^1.0.1",
     "babel-preset-stage-0": "^6.3.13",
     "classnames": ">=2.1.2",
-    "cpx": "^1.2.1",
     "cross-env": "^1.0.4",
     "css-loader": "^0.21.0",
     "eslint": "^1.10.1",

--- a/src/components/Col.js
+++ b/src/components/Col.js
@@ -1,5 +1,5 @@
 import React, {Component, PropTypes} from 'react';
-import style from '../style';
+import style from 'flexboxgrid';
 
 const ModificatorType = PropTypes.oneOfType([PropTypes.number, PropTypes.bool]);
 

--- a/src/components/Grid.js
+++ b/src/components/Grid.js
@@ -1,6 +1,6 @@
 import React, {Component, PropTypes} from 'react';
 import classNames from 'classnames';
-import style from '../style';
+import style from 'flexboxgrid';
 
 export default class Grid extends Component {
   render() {

--- a/src/components/Row.js
+++ b/src/components/Row.js
@@ -1,6 +1,6 @@
 import React, {Component, PropTypes} from 'react';
 import classNames from 'classnames';
-import style from '../style';
+import style from 'flexboxgrid';
 
 const ModificatorType = PropTypes.oneOf(['xs', 'sm', 'md', 'lg']);
 const modificatorKeys = ['start', 'center', 'end', 'top', 'middle', 'bottom', 'around', 'between', 'first', 'last'];

--- a/src/style.scss
+++ b/src/style.scss
@@ -1,1 +1,0 @@
-@import '~flexboxgrid';

--- a/test/components/Col.spec.js
+++ b/test/components/Col.spec.js
@@ -3,7 +3,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import TestUtils from 'react-addons-test-utils';
 import Col from '../../src/components/Col';
-import style from '../../src/style';
+import style from 'flexboxgrid';
 
 describe('Col', () => {
   it('Should add classes equals to props', () => {

--- a/test/components/Grid.spec.js
+++ b/test/components/Grid.spec.js
@@ -3,7 +3,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import TestUtils from 'react-addons-test-utils';
 import Grid from '../../src/components/Grid';
-import style from '../../src/style';
+import style from 'flexboxgrid';
 
 
 describe('Grid', () => {

--- a/test/components/Row.spec.js
+++ b/test/components/Row.spec.js
@@ -3,7 +3,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import TestUtils from 'react-addons-test-utils';
 import Row from '../../src/components/Row';
-import style from '../../src/style';
+import style from 'flexboxgrid';
 
 describe('Row', () => {
   it('Should add "row" class', () => {


### PR DESCRIPTION
Currently webpack, sass-loader and .scss extension config are requirements.

Since **flexboxgrid** is a peer dependency, we can import it straightly making react-flexbox-grid also compatible with browserify, jspm and etc(if CSS modules and loader config are set). This change also fixes/avoids #6 #2  and possibly #3.