### PR TITLE
Removing extra start="md" on demo home page

### DIFF
--- a/doc/app/components/home/index.jsx
+++ b/doc/app/components/home/index.jsx
@@ -120,7 +120,7 @@ const Home = () => (
         <h3><code>.end-</code></h3>
         <Row>
           <Box type="container" xs={12}>
-            <Row end="xs" start="md">
+            <Row end="xs">
               <Box type="nested" xs={6} />
             </Row>
           </Box>


### PR DESCRIPTION
On the main page, it seems like start="md" was accidentally added resulting in a failed demo on large screen devices for end. Removing the extraneous code.