### PR TITLE
Remove classnames and babel-polyfill peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "babel-polyfill": ">=6.0.0",
     "flexboxgrid": "^6.3.0",
     "react": "^0.14.3 || ^15.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
   "license": "MIT",
   "peerDependencies": {
     "babel-polyfill": ">=6.0.0",
-    "classnames": ">=2.1.2",
     "flexboxgrid": "^6.3.0",
     "react": "^0.14.3 || ^15.0.0"
   }

--- a/src/combineIfExist.js
+++ b/src/combineIfExist.js
@@ -1,0 +1,19 @@
+export default function(a, b) {
+  function reduceToString(arg) {
+    if (Array.isArray(arg)) {
+      return arg.reduce(function reduxor(acc, cur) {
+        return acc + ' ' + cur;
+      });
+    }
+    return arg || '';
+  }
+
+  const stringA = reduceToString(a);
+  const stringB = reduceToString(b);
+
+  if (stringA.length > 0 && stringB.length > 0) {
+    return stringA + ' ' + stringB;
+  }
+
+  return stringA || stringB;
+}

--- a/src/combineIfExist.js
+++ b/src/combineIfExist.js
@@ -1,9 +1,7 @@
 export default function(a, b) {
   function reduceToString(arg) {
     if (Array.isArray(arg)) {
-      return arg.reduce(function reduxor(acc, cur) {
-        return acc + ' ' + cur;
-      });
+      return arg.join(' ');
     }
     return arg || '';
   }

--- a/src/components/Grid.js
+++ b/src/components/Grid.js
@@ -1,5 +1,5 @@
 import React, { PropTypes } from 'react';
-import classNames from 'classnames';
+import classNames from '../combineIfExist';
 import createProps from '../createProps';
 import style from 'flexboxgrid';
 

--- a/src/components/Row.js
+++ b/src/components/Row.js
@@ -1,5 +1,5 @@
 import React, { PropTypes } from 'react';
-import classNames from 'classnames';
+import classNames from '../combineIfExist';
 import createProps from '../createProps';
 import style from 'flexboxgrid';
 


### PR DESCRIPTION
Resolves #49 
Resolves #51 

Wrote a small local utility to replace classnames.

Took out babel-polyfill as well. It is still a devDependency so mocha and webpack still work fine 👍 
