### PR TITLE
Remove runtime dependency on classnames & babel-polyfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,7 @@ Installation
 React-Flexbox-Grid can be installed as an [npm package](https://www.npmjs.com/package/react-flexbox-grid);
 
 ```
-//dependencies
-npm install classnames
+// peer dependency
 npm install flexboxgrid
 
 npm install react-flexbox-grid
@@ -65,7 +64,7 @@ Once you have the workflow ready, you can just require and use the components:
 
 ```jsx
 import React from `react`;
-import { Grid } from `react-flexbox-grid/lib/index`;
+import { Grid } from `react-flexbox-grid`;
 
 React.render(<Grid />, document.querySelector('#main'));
 ```

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -6,7 +6,6 @@ module.exports = function karmaConfig(config) {
     singleRun: true,
     frameworks: ['mocha'],
     files: [
-      './node_modules/phantomjs-polyfill/bind-polyfill.js',
       './node_modules/babel-polyfill/browser.js',
       'tests.webpack.js',
       'test/reactErrors.js'

--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "babel-polyfill": ">=6.0.0",
     "flexboxgrid": "^6.3.0",
     "react": "^0.14.3 || ^15.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "mocha": "^2.3.4",
     "node-sass": "^3.4.2",
     "phantomjs": "^1.9.19",
-    "phantomjs-polyfill": "0.0.1",
     "postcss-loader": "^0.7.0",
     "react": "^15.2.0",
     "react-addons-test-utils": "^15.2.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "babel-preset-react": "^6.3.13",
     "babel-preset-react-hmre": "^1.0.1",
     "babel-preset-stage-0": "^6.3.13",
-    "classnames": ">=2.1.2",
     "cpx": "^1.2.1",
     "cross-env": "^1.0.4",
     "css-loader": "^0.21.0",
@@ -86,7 +85,6 @@
   "license": "MIT",
   "peerDependencies": {
     "babel-polyfill": ">=6.0.0",
-    "classnames": ">=2.1.2",
     "flexboxgrid": "^6.3.0",
     "react": "^0.14.3 || ^15.0.0"
   }

--- a/src/components/Col.js
+++ b/src/components/Col.js
@@ -44,14 +44,13 @@ function getClassNames(props) {
   return Object.keys(props)
     .filter(key => classMap[key])
     .map(key => style[Number.isInteger(props[key]) ? (classMap[key] + '-' + props[key]) : classMap[key]])
-    .concat(extraClasses)
-    .join(' ');
+    .concat(extraClasses);
 }
 
 export default function Col(props) {
-  const className = getClassNames(props);
+  const classNames = getClassNames(props);
 
-  return React.createElement(props.tagName || 'div', createProps(propTypes, props, className));
+  return React.createElement(props.tagName || 'div', createProps(propTypes, props, classNames));
 }
 
 Col.propTypes = propTypes;

--- a/src/components/Col.js
+++ b/src/components/Col.js
@@ -30,6 +30,10 @@ const classMap = {
   lgOffset: 'col-lg-offset'
 };
 
+function isInteger(value) {
+  return typeof value === 'number' && isFinite(value) && Math.floor(value) === value;
+}
+
 function getClassNames(props) {
   const extraClasses = [];
 
@@ -43,7 +47,7 @@ function getClassNames(props) {
 
   return Object.keys(props)
     .filter(key => classMap[key])
-    .map(key => style[Number.isInteger(props[key]) ? (classMap[key] + '-' + props[key]) : classMap[key]])
+    .map(key => style[isInteger(props[key]) ? (classMap[key] + '-' + props[key]) : classMap[key]])
     .concat(extraClasses);
 }
 

--- a/src/components/Grid.js
+++ b/src/components/Grid.js
@@ -1,5 +1,4 @@
 import React, { PropTypes } from 'react';
-import classNames from 'classnames';
 import createProps from '../createProps';
 import style from 'flexboxgrid';
 
@@ -12,9 +11,9 @@ const propTypes = {
 
 export default function Grid(props) {
   const containerClass = style[props.fluid ? 'container-fluid' : 'container'];
-  const className = classNames(props.className, containerClass);
+  const classNames = [props.className, containerClass];
 
-  return React.createElement(props.tagName || 'div', createProps(propTypes, props, className));
+  return React.createElement(props.tagName || 'div', createProps(propTypes, props, classNames));
 }
 
 Grid.propTypes = propTypes;

--- a/src/components/Row.js
+++ b/src/components/Row.js
@@ -1,5 +1,4 @@
 import React, { PropTypes } from 'react';
-import classNames from 'classnames';
 import createProps from '../createProps';
 import style from 'flexboxgrid';
 
@@ -24,7 +23,7 @@ const propTypes = {
 };
 
 function getClassNames(props) {
-  const modificators = [style.row];
+  const modificators = [props.className, style.row];
 
   for (let i = 0; i < modificatorKeys.length; ++i) {
     const key = modificatorKeys[i];
@@ -38,7 +37,7 @@ function getClassNames(props) {
     modificators.push(style.reverse);
   }
 
-  return classNames(props.className, modificators);
+  return modificators;
 }
 
 export default function Row(props) {

--- a/src/createProps.js
+++ b/src/createProps.js
@@ -1,9 +1,10 @@
-export default function createProps(propTypes, props, className) {
+export default function createProps(propTypes, props, classNames) {
   const newProps = {};
 
   Object.keys(props)
     .filter(key => (key === 'children' || !propTypes[key]))
     .forEach(key => (newProps[key] = props[key]));
 
+  const className = classNames.filter(cn => cn).join(' ');
   return Object.assign({}, newProps, { className });
 }


### PR DESCRIPTION
This does much the same as PR #64 for solving issue #49, but rather than creating a custom `classnames` replacement, it changes the call parameters of `createProps()` to expect an array of class names that it then filters.

This PR also resolves #51 by adding an inline `isInteger()` replacement for `Number.isInteger()`, which isn't supported by IE. I also dropped the `phantomjs-polyfill` dependency as it's not needed.
