### PR TITLE
Allow column reordering

### DIFF
--- a/src/components/Col.js
+++ b/src/components/Col.js
@@ -1,8 +1,7 @@
+import style from 'flexboxgrid';
 import React, { PropTypes } from 'react';
 import createProps from '../createProps';
-import style from 'flexboxgrid';
-
-const ColumnSizeType = PropTypes.oneOfType([PropTypes.number, PropTypes.bool]);
+import { ColumnSizeType } from '../types';
 
 const propTypes = {
   xs: ColumnSizeType,

--- a/src/components/Col.js
+++ b/src/components/Col.js
@@ -2,13 +2,13 @@ import React, { PropTypes } from 'react';
 import createProps from '../createProps';
 import style from 'flexboxgrid';
 
-const ModificatorType = PropTypes.oneOfType([PropTypes.number, PropTypes.bool]);
+const ColumnSizeType = PropTypes.oneOfType([PropTypes.number, PropTypes.bool]);
 
 const propTypes = {
-  xs: ModificatorType,
-  sm: ModificatorType,
-  md: ModificatorType,
-  lg: ModificatorType,
+  xs: ColumnSizeType,
+  sm: ColumnSizeType,
+  md: ColumnSizeType,
+  lg: ColumnSizeType,
   xsOffset: PropTypes.number,
   smOffset: PropTypes.number,
   mdOffset: PropTypes.number,

--- a/src/components/Col.js
+++ b/src/components/Col.js
@@ -1,7 +1,7 @@
 import style from 'flexboxgrid';
 import React, { PropTypes } from 'react';
 import createProps from '../createProps';
-import { ColumnSizeType } from '../types';
+import { ColumnSizeType, ViewportSizeType } from '../types';
 
 const propTypes = {
   xs: ColumnSizeType,
@@ -12,6 +12,8 @@ const propTypes = {
   smOffset: PropTypes.number,
   mdOffset: PropTypes.number,
   lgOffset: PropTypes.number,
+  first: ViewportSizeType,
+  last: ViewportSizeType,
   reverse: PropTypes.bool,
   className: PropTypes.string,
   tagName: PropTypes.string,
@@ -34,6 +36,14 @@ function getClassNames(props) {
 
   if (props.className) {
     extraClasses.push(props.className);
+  }
+
+  if (props.first) {
+    extraClasses.push(style['first-' + props.first]);
+  }
+
+  if (props.last) {
+    extraClasses.push(style['last-' + props.last]);
   }
 
   if (props.reverse) {

--- a/src/components/Row.js
+++ b/src/components/Row.js
@@ -3,21 +3,21 @@ import classNames from 'classnames';
 import createProps from '../createProps';
 import style from 'flexboxgrid';
 
-const ModificatorType = PropTypes.oneOf(['xs', 'sm', 'md', 'lg']);
+const ViewportSizeType = PropTypes.oneOf(['xs', 'sm', 'md', 'lg']);
 const modificatorKeys = ['start', 'center', 'end', 'top', 'middle', 'bottom', 'around', 'between', 'first', 'last'];
 
 const propTypes = {
   reverse: PropTypes.bool,
-  start: ModificatorType,
-  center: ModificatorType,
-  end: ModificatorType,
-  top: ModificatorType,
-  middle: ModificatorType,
-  bottom: ModificatorType,
-  around: ModificatorType,
-  between: ModificatorType,
-  first: ModificatorType,
-  last: ModificatorType,
+  start: ViewportSizeType,
+  center: ViewportSizeType,
+  end: ViewportSizeType,
+  top: ViewportSizeType,
+  middle: ViewportSizeType,
+  bottom: ViewportSizeType,
+  around: ViewportSizeType,
+  between: ViewportSizeType,
+  first: ViewportSizeType,
+  last: ViewportSizeType,
   className: PropTypes.string,
   tagName: PropTypes.string,
   children: PropTypes.node

--- a/src/components/Row.js
+++ b/src/components/Row.js
@@ -4,7 +4,7 @@ import createProps from '../createProps';
 import style from 'flexboxgrid';
 
 const ViewportSizeType = PropTypes.oneOf(['xs', 'sm', 'md', 'lg']);
-const modificatorKeys = ['start', 'center', 'end', 'top', 'middle', 'bottom', 'around', 'between', 'first', 'last'];
+const rowKeys = ['start', 'center', 'end', 'top', 'middle', 'bottom', 'around', 'between', 'first', 'last'];
 
 const propTypes = {
   reverse: PropTypes.bool,
@@ -26,8 +26,8 @@ const propTypes = {
 function getClassNames(props) {
   const modificators = [style.row];
 
-  for (let i = 0; i < modificatorKeys.length; ++i) {
-    const key = modificatorKeys[i];
+  for (let i = 0; i < rowKeys.length; ++i) {
+    const key = rowKeys[i];
     const value = props[key];
     if (value) {
       modificators.push(style[`${key}-${value}`]);

--- a/src/components/Row.js
+++ b/src/components/Row.js
@@ -1,9 +1,9 @@
-import React, { PropTypes } from 'react';
 import classNames from 'classnames';
-import createProps from '../createProps';
 import style from 'flexboxgrid';
+import React, { PropTypes } from 'react';
+import createProps from '../createProps';
+import { ViewportSizeType } from '../types';
 
-const ViewportSizeType = PropTypes.oneOf(['xs', 'sm', 'md', 'lg']);
 const rowKeys = ['start', 'center', 'end', 'top', 'middle', 'bottom', 'around', 'between', 'first', 'last'];
 
 const propTypes = {

--- a/src/components/Row.js
+++ b/src/components/Row.js
@@ -4,7 +4,7 @@ import React, { PropTypes } from 'react';
 import createProps from '../createProps';
 import { ViewportSizeType } from '../types';
 
-const rowKeys = ['start', 'center', 'end', 'top', 'middle', 'bottom', 'around', 'between', 'first', 'last'];
+const rowKeys = ['start', 'center', 'end', 'top', 'middle', 'bottom', 'around', 'between'];
 
 const propTypes = {
   reverse: PropTypes.bool,
@@ -16,8 +16,6 @@ const propTypes = {
   bottom: ViewportSizeType,
   around: ViewportSizeType,
   between: ViewportSizeType,
-  first: ViewportSizeType,
-  last: ViewportSizeType,
   className: PropTypes.string,
   tagName: PropTypes.string,
   children: PropTypes.node

--- a/src/types.js
+++ b/src/types.js
@@ -1,0 +1,4 @@
+import { PropTypes } from 'react';
+
+export const ColumnSizeType = PropTypes.oneOfType([PropTypes.number, PropTypes.bool]);
+export const ViewportSizeType = PropTypes.oneOf(['xs', 'sm', 'md', 'lg']);

--- a/test/components/Col.spec.js
+++ b/test/components/Col.spec.js
@@ -18,7 +18,7 @@ describe('Col', () => {
   });
 
   it('Should add "first-*" class if "first" property is set', () => {
-    renderer.render(<Col first='md'/>);
+    renderer.render(<Col first="md"/>);
     expect(renderer.getRenderOutput().props.className).toContain(style['first-md']);
   });
 

--- a/test/components/Col.spec.js
+++ b/test/components/Col.spec.js
@@ -17,6 +17,11 @@ describe('Col', () => {
     expect(className).toContain(style['col-lg-4']);
   });
 
+  it('Should add "first-*" class if "first" property is set', () => {
+    renderer.render(<Col first='md'/>);
+    expect(renderer.getRenderOutput().props.className).toContain(style['first-md']);
+  });
+
   it('Should add "reverse" class if "reverse" property is true', () => {
     renderer.render(<Col reverse/>);
     expect(renderer.getRenderOutput().props.className).toContain(style.reverse);

--- a/test/components/Row.spec.js
+++ b/test/components/Row.spec.js
@@ -35,8 +35,6 @@ describe('Row', () => {
         bottom="sm"
         around="md"
         between="lg"
-        first="xs"
-        last="sm"
       />
     );
     const { className } = renderer.getRenderOutput().props;
@@ -50,8 +48,6 @@ describe('Row', () => {
     expect(className).toContain(style['bottom-sm']);
     expect(className).toContain(style['around-md']);
     expect(className).toContain(style['between-lg']);
-    expect(className).toContain(style['first-xs']);
-    expect(className).toContain(style['last-sm']);
   });
 
   it('Should support custom tag name', () => {


### PR DESCRIPTION
This fixes #22 by moving the `first` and `last` props from `Row` to `Col`, as they are in `flexboxgrid.css`.

To verify that they work together, I've a build [here](/eemeli/react-flexbox-grid/tree/74f2ac5) that has this and PR #66 both merged, and includes the `lib/` build artifacts.
