### PR TITLE
install classnames and flexboxgrid as dependencies in react-flexbox-grid

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react-component"
   ],
   "devDependencies": {
+    "babel-polyfill": ">=6.0.0",
     "autoprefixer": "^6.0.3",
     "babel-cli": "^6.4.0",
     "babel-core": "^6.4.0",
@@ -84,8 +85,7 @@
     "test:watch": "cross-env NODE_ENV=test karma start --no-single-run"
   },
   "license": "MIT",
-  "peerDependencies": {
-    "babel-polyfill": ">=6.0.0",
+  "dependencies": {
     "classnames": ">=2.1.2",
     "flexboxgrid": "^6.3.0",
     "react": "^0.14.3 || ^15.0.0"

--- a/server.js
+++ b/server.js
@@ -21,7 +21,7 @@ app.get('*', (req, resp) => {
   resp.sendFile(path.join(__dirname, './spec/index.html'));
 });
 
-app.listen(port, '0.0.0.0', (err) => {
+app.listen(port, 'localhost', (err) => {
   if (err) {
     console.log(err);
     return;
@@ -29,5 +29,5 @@ app.listen(port, '0.0.0.0', (err) => {
 
   console.log(path.join(__dirname, './spec/index.html'));
 
-  console.log('Listening at http://0.0.0.0:' + port);
+  console.log('Listening at http://localhost:' + port);
 });

--- a/src/components/Col.js
+++ b/src/components/Col.js
@@ -1,6 +1,6 @@
 import React, { PropTypes } from 'react';
 import createProps from '../createProps';
-import style from 'flexboxgrid';
+import style from 'style!css?modules!flexboxgrid';
 
 const ModificatorType = PropTypes.oneOfType([PropTypes.number, PropTypes.bool]);
 

--- a/src/components/Grid.js
+++ b/src/components/Grid.js
@@ -1,7 +1,7 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
 import createProps from '../createProps';
-import style from 'flexboxgrid';
+import style from 'style!css?modules!flexboxgrid';
 
 const propTypes = {
   fluid: PropTypes.bool,

--- a/src/components/Row.js
+++ b/src/components/Row.js
@@ -1,7 +1,7 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
 import createProps from '../createProps';
-import style from 'flexboxgrid';
+import style from 'style!css?modules!flexboxgrid';
 
 const ModificatorType = PropTypes.oneOf(['xs', 'sm', 'md', 'lg']);
 const modificatorKeys = ['start', 'center', 'end', 'top', 'middle', 'bottom', 'around', 'between', 'first', 'last'];

--- a/webpack.config.development.js
+++ b/webpack.config.development.js
@@ -27,7 +27,8 @@ module.exports = {
         loader: 'babel'
       },
       {
-        test: /(\.scss|\.css)$/,
+        test: /(\.scss)$/,
+        exclude: path.join(__dirname, 'src'),
         loader: ExtractTextPlugin.extract('style-loader', 'css?sourceMap&modules&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]!postcss!sass?sourceMap')
       }
     ]


### PR DESCRIPTION
I think `classnames` and `flexboxgrid` should not be installed by the users.

and also put import with loaders in `import style from 'style!css?modules!flexboxgrid';`. I think this can take less configuration for others to use the project. How do you think? thanks!