### PR TITLE
Lookup classnames using with customizable function

### DIFF
--- a/src/classNames.js
+++ b/src/classNames.js
@@ -1,7 +1,7 @@
 import style from 'flexboxgrid';
 
 function defaultClassNameLookup(className) {
-  return style[className];
+  return style[className] || className;
 }
 
 let classNameLookup = defaultClassNameLookup;

--- a/src/classNames.js
+++ b/src/classNames.js
@@ -1,15 +1,5 @@
-import style from 'flexboxgrid';
-
-function defaultClassNameLookup(className) {
-  return style[className] || className;
-}
-
-let classNameLookup = defaultClassNameLookup;
-
-export function setClassNameLookup(fn) {
-  classNameLookup = fn || defaultClassNameLookup;
-}
+import styles from 'flexboxgrid';
 
 export default function getClass(className) {
-  return classNameLookup(className);
+  return (styles && styles[className]) ? styles[className] : className;
 }

--- a/src/classNames.js
+++ b/src/classNames.js
@@ -1,0 +1,15 @@
+import style from 'flexboxgrid';
+
+function defaultClassNameLookup(className) {
+  return style[className];
+}
+
+let classNameLookup = defaultClassNameLookup;
+
+export function setClassNameLookup(fn) {
+  classNameLookup = fn || defaultClassNameLookup;
+}
+
+export default function getClass(className) {
+  return classNameLookup(className);
+}

--- a/src/components/Col.js
+++ b/src/components/Col.js
@@ -1,6 +1,6 @@
-import style from 'flexboxgrid';
 import React, { PropTypes } from 'react';
 import createProps from '../createProps';
+import getClass from '../classNames';
 import { ColumnSizeType, ViewportSizeType } from '../types';
 
 const propTypes = {
@@ -43,20 +43,20 @@ function getClassNames(props) {
   }
 
   if (props.first) {
-    extraClasses.push(style['first-' + props.first]);
+    extraClasses.push(getClass('first-' + props.first));
   }
 
   if (props.last) {
-    extraClasses.push(style['last-' + props.last]);
+    extraClasses.push(getClass('last-' + props.last));
   }
 
   if (props.reverse) {
-    extraClasses.push(style.reverse);
+    extraClasses.push(getClass('reverse'));
   }
 
   return Object.keys(props)
     .filter(key => classMap[key])
-    .map(key => style[isInteger(props[key]) ? (classMap[key] + '-' + props[key]) : classMap[key]])
+    .map(key => getClass(isInteger(props[key]) ? (classMap[key] + '-' + props[key]) : classMap[key]))
     .concat(extraClasses);
 }
 

--- a/src/components/Grid.js
+++ b/src/components/Grid.js
@@ -1,6 +1,6 @@
 import React, { PropTypes } from 'react';
 import createProps from '../createProps';
-import style from 'flexboxgrid';
+import getClass from '../classNames';
 
 const propTypes = {
   fluid: PropTypes.bool,
@@ -10,7 +10,7 @@ const propTypes = {
 };
 
 export default function Grid(props) {
-  const containerClass = style[props.fluid ? 'container-fluid' : 'container'];
+  const containerClass = getClass(props.fluid ? 'container-fluid' : 'container');
   const classNames = [props.className, containerClass];
 
   return React.createElement(props.tagName || 'div', createProps(propTypes, props, classNames));

--- a/src/components/Row.js
+++ b/src/components/Row.js
@@ -1,4 +1,4 @@
-import style from 'flexboxgrid';
+import getClass from '../classNames';
 import React, { PropTypes } from 'react';
 import createProps from '../createProps';
 import { ViewportSizeType } from '../types';
@@ -21,18 +21,18 @@ const propTypes = {
 };
 
 function getClassNames(props) {
-  const modificators = [props.className, style.row];
+  const modificators = [props.className, getClass('row')];
 
   for (let i = 0; i < rowKeys.length; ++i) {
     const key = rowKeys[i];
     const value = props[key];
     if (value) {
-      modificators.push(style[`${key}-${value}`]);
+      modificators.push(getClass(`${key}-${value}`));
     }
   }
 
   if (props.reverse) {
-    modificators.push(style.reverse);
+    modificators.push(getClass('reverse'));
   }
 
   return modificators;

--- a/test/classNames.spec.js
+++ b/test/classNames.spec.js
@@ -1,8 +1,9 @@
 import expect from 'expect';
 import React from 'react';
+import style from 'flexboxgrid';
 import TestUtils from 'react-addons-test-utils';
 import Col from '../src/components/Col';
-import { setClassNameLookup } from '../src/classNames';
+import getClass, { setClassNameLookup } from '../src/classNames';
 
 const renderer = TestUtils.createRenderer();
 
@@ -10,8 +11,13 @@ describe('classNames lookups', () => {
   afterEach(() => {
     setClassNameLookup();
   });
-
-  it('Uses a custom className lookup function', () => {
+  it('translates known styles', () => {
+    expect(getClass('col-xs')).toEqual(style['col-xs']);
+  });
+  it('falls back to returning unknown classnames', () => {
+    expect(getClass('blah-blah-blah')).toEqual('blah-blah-blah');
+  });
+  it('cn use a custom className lookup function', () => {
     setClassNameLookup(name => `test-${name}`);
     renderer.render(<Col xs={12} sm={8} md={6} lg={4} />);
     const { type, props: { className } } = renderer.getRenderOutput();

--- a/test/classNames.spec.js
+++ b/test/classNames.spec.js
@@ -1,0 +1,24 @@
+import expect from 'expect';
+import React from 'react';
+import TestUtils from 'react-addons-test-utils';
+import Col from '../src/components/Col';
+import { setClassNameLookup } from '../src/classNames';
+
+const renderer = TestUtils.createRenderer();
+
+describe('classNames lookups', () => {
+  afterEach(() => {
+    setClassNameLookup();
+  });
+
+  it('Uses a custom className lookup function', () => {
+    setClassNameLookup(name => `test-${name}`);
+    renderer.render(<Col xs={12} sm={8} md={6} lg={4} />);
+    const { type, props: { className } } = renderer.getRenderOutput();
+    expect(type).toBe('div');
+    expect(className).toContain('test-col-xs-12');
+    expect(className).toContain('test-col-sm-8');
+    expect(className).toContain('test-col-md-6');
+    expect(className).toContain('test-col-lg-4');
+  });
+});

--- a/test/classNames.spec.js
+++ b/test/classNames.spec.js
@@ -8,23 +8,10 @@ import getClass, { setClassNameLookup } from '../src/classNames';
 const renderer = TestUtils.createRenderer();
 
 describe('classNames lookups', () => {
-  afterEach(() => {
-    setClassNameLookup();
-  });
   it('translates known styles', () => {
     expect(getClass('col-xs')).toEqual(style['col-xs']);
   });
   it('falls back to returning unknown classnames', () => {
     expect(getClass('blah-blah-blah')).toEqual('blah-blah-blah');
-  });
-  it('cn use a custom className lookup function', () => {
-    setClassNameLookup(name => `test-${name}`);
-    renderer.render(<Col xs={12} sm={8} md={6} lg={4} />);
-    const { type, props: { className } } = renderer.getRenderOutput();
-    expect(type).toBe('div');
-    expect(className).toContain('test-col-xs-12');
-    expect(className).toContain('test-col-sm-8');
-    expect(className).toContain('test-col-md-6');
-    expect(className).toContain('test-col-lg-4');
   });
 });

--- a/test/classNames.spec.js
+++ b/test/classNames.spec.js
@@ -1,11 +1,6 @@
 import expect from 'expect';
-import React from 'react';
 import style from 'flexboxgrid';
-import TestUtils from 'react-addons-test-utils';
-import Col from '../src/components/Col';
-import getClass, { setClassNameLookup } from '../src/classNames';
-
-const renderer = TestUtils.createRenderer();
+import getClass from '../src/classNames';
 
 describe('classNames lookups', () => {
   it('translates known styles', () => {


### PR DESCRIPTION
So... I really like what you've done with the library, it's pretty much exactly what I was looking for in a responsive grid layout.

However, my project doesn't use css-modules and it bugs me to see the weird classnames in the DOM when I inspect it.  https://github.com/roylee0704/react-flexbox-grid/issues/60 seems to concur with my opinion.

This adds a `getClass` method that by default will lookup classes in the css modules `style` object.  However, I can add a simple function: `setClassNameLookup(cn => cn);` and just have it return the class name for me.  

A further improvement (IMO) would be to change the `defaultClassNameLookup` function so it would return the classname itself if it's not found in the style object.  That would prevent the empty classes bug that's caused by not setting up webpack with css module support.

That would take you further from css-modules though, so I choose not to do that.   More than happy to do so if you think it's a good idea though.

I also choose not to document and export `setClassNameLookup`, but can do so if you think best.
