### PR TITLE
Add extension onto flexboxgrid import

### DIFF
--- a/src/classNames.js
+++ b/src/classNames.js
@@ -1,4 +1,4 @@
-import styles from 'flexboxgrid';
+import styles from 'flexboxgrid/dist/flexboxgrid.css';
 
 export default function getClass(className) {
   return (styles && styles[className]) ? styles[className] : className;


### PR DESCRIPTION
Found one more thing 😁 

This makes it a bit easier to mock when testing with Jest, since testing setups have a role saying to mock out '*.css'

I just lost a bit of time debugging why Jest wasn't mocking the css even though I had the recommended rule:
```json
    "moduleNameMapper": {
        "\\.(css|less|scss)$": "<rootDir>/config/styleMock.js"
    }
```

For now I've changed it to:

```json
    "moduleNameMapper": {
        "\\.(css|less|scss)$": "<rootDir>/config/styleMock.js",
        "flexboxgrid$": "<rootDir>/config/styleMock.js"
   }
```

which works fine, but would be nicer if I could just use the original rule, especially since the [Jest Docs](http://facebook.github.io/jest/docs/webpack.html#mocking-css-modules) recommend that.