### PR TITLE
Eliminate Col's reverse property

### DIFF
--- a/react-flexbox-grid.d.ts
+++ b/react-flexbox-grid.d.ts
@@ -40,7 +40,6 @@ declare namespace __ReactFlexboxGrid {
     readonly lgOffset?: number,
     readonly first?: ViewportSizeType,
     readonly last?: ViewportSizeType,
-    readonly reverse?: boolean,
     readonly className?: string,
     readonly tagName?: string,
   }

--- a/src/components/Col.js
+++ b/src/components/Col.js
@@ -14,7 +14,6 @@ const propTypes = {
   lgOffset: PropTypes.number,
   first: ViewportSizeType,
   last: ViewportSizeType,
-  reverse: PropTypes.bool,
   className: PropTypes.string,
   tagName: PropTypes.string,
   children: PropTypes.node
@@ -48,10 +47,6 @@ function getColClassNames(props) {
 
   if (props.last) {
     extraClasses.push(getClass('last-' + props.last));
-  }
-
-  if (props.reverse) {
-    extraClasses.push(getClass('reverse'));
   }
 
   return Object.keys(props)

--- a/test/components/Col.spec.js
+++ b/test/components/Col.spec.js
@@ -28,11 +28,6 @@ describe('Col', () => {
     expect(renderer.getRenderOutput().props.className).toContain(style['first-md']);
   });
 
-  it('Should add "reverse" class if "reverse" property is true', () => {
-    renderer.render(<Col reverse/>);
-    expect(renderer.getRenderOutput().props.className).toContain(style.reverse);
-  });
-
   it('Should not replace class', () => {
     renderer.render(<Col className="foo" md={3} />);
 


### PR DESCRIPTION
Col's reverse property was a boolean that would apply the 'reverse' class if true.  However, there is no support for reverse for columns in flexboxgrid.  There is a .col.reverse class defined, but it sets the flex-direction to column-reverse, which has no effect on an element that is not displayed as flex.  Furthermore, columns are not given the .col class in the way that rows are given the .row class, so the designation of .reverse on a Col would not even cause these rules to be applied.

The .col.reverse class appears to be lint, left over from an abandoned attempt to support columnar flexboxes in the flexboxgrid package.  See:  https://github.com/kristoferjoseph/flexboxgrid/issues/173