### PR TITLE
Remove deprecated "es2015-loose" preset

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,5 @@
 {
-  "presets": ["es2015-loose", "stage-0", "react"],
+  "presets": [["es2015", {"loose": true}], "stage-0", "react"],
   "env": {
     "development": {
       "presets": ["react-hmre"]

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "babel-loader": "^6.2.1",
     "babel-plugin-react-transform": "^2.0.0",
     "babel-polyfill": "^6.3.14",
-    "babel-preset-es2015-loose": "^6.1.4",
+    "babel-preset-es2015": "^6.1.4",
     "babel-preset-react": "^6.3.13",
     "babel-preset-react-hmre": "^1.0.1",
     "babel-preset-stage-0": "^6.3.13",


### PR DESCRIPTION
 Since [babel-preset-es2015-loose](https://github.com/bkonkle/babel-preset-es2015-loose) is [deprecated](https://github.com/bkonkle/babel-preset-es2015-loose#deprecation-warning), it's better to move to [babel-preset-2015](https://github.com/babel/babel/tree/master/packages/babel-preset-es2015) with [loose](https://github.com/babel/babel/tree/master/packages/babel-preset-es2015#loose) option. 

This removes warning about deprecated package using.