### PR TITLE
Upgrading react to v15.5.4.

### DIFF
--- a/doc/app/components/box/index.jsx
+++ b/doc/app/components/box/index.jsx
@@ -1,13 +1,14 @@
-import React, {PropTypes} from 'react';
-import {Col} from 'react-flexbox-grid';
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Col } from 'react-flexbox-grid';
 import box from './style';
 
 const Box = (props) => {
   return (
     <Col {...props}>
-        <div className = {box[props.type || 'box']}>
-          {props.children}
-        </div>
+      <div className={box[props.type || 'box']}>
+        {props.children}
+      </div>
     </Col>
   );
 };

--- a/doc/app/components/button/index.jsx
+++ b/doc/app/components/button/index.jsx
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import style from './style';
 
 const Button = (props) => {

--- a/doc/app/components/section/index.jsx
+++ b/doc/app/components/section/index.jsx
@@ -1,9 +1,10 @@
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import style from './style';
 
 const Section = (props) => {
   return (
-    <section className = {style.section}>
+    <section className={style.section}>
       <h2>{props.title}</h2>
       <p>{props.description}</p>
       {props.children}

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "react-component"
   ],
   "dependencies": {
-    "flexboxgrid": "^6.3.0"
+    "flexboxgrid": "^6.3.0",
+    "prop-types": "^15.5.8"
   },
   "devDependencies": {
     "@types/react": "*",
@@ -60,9 +61,9 @@
     "node-sass": "^3.4.2",
     "phantomjs": "^1.9.19",
     "postcss-loader": "^0.7.0",
-    "react": "^15.2.0",
-    "react-addons-test-utils": "^15.2.0",
-    "react-dom": "^15.2.0",
+    "react": "^15.5.4",
+    "react-addons-test-utils": "^15.5.1",
+    "react-dom": "^15.5.4",
     "react-hot-loader": "^1.3.0",
     "redbox-react": "^1.1.1",
     "rimraf": "^2.4.4",
@@ -87,7 +88,7 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "react": "^0.14.3 || ^15.0.0"
+    "react": "^0.14.3 || ^15.5.4"
   },
   "types": "react-flexbox-grid.d.ts"
 }

--- a/src/components/Col.js
+++ b/src/components/Col.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import createProps from '../createProps';
 import getClass from '../classNames';
 import { ColumnSizeType, ViewportSizeType } from '../types';

--- a/src/components/Grid.js
+++ b/src/components/Grid.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import createProps from '../createProps';
 import getClass from '../classNames';
 

--- a/src/components/Row.js
+++ b/src/components/Row.js
@@ -1,5 +1,6 @@
 import getClass from '../classNames';
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import createProps from '../createProps';
 import { ViewportSizeType } from '../types';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2058,9 +2058,9 @@ fastparse@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/fastparse/-/fastparse-1.1.1.tgz#d1e2643b38a94d7583b479060e6c4affc94071f8"
 
-fbjs@^0.8.1, fbjs@^0.8.4:
-  version "0.8.9"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.9.tgz#180247fbd347dcc9004517b904f865400a0c8f14"
+fbjs@^0.8.4, fbjs@^0.8.9:
+  version "0.8.12"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.12.tgz#10b5d92f76d45575fd63a217d4ea02bea2f8ed04"
   dependencies:
     core-js "^1.0.0"
     isomorphic-fetch "^2.1.1"
@@ -4220,6 +4220,12 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
+prop-types@^15.5.7, prop-types@^15.5.8, prop-types@~15.5.7:
+  version "15.5.8"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.8.tgz#6b7b2e141083be38c8595aa51fc55775c7199394"
+  dependencies:
+    fbjs "^0.8.9"
+
 proxy-addr@~1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-1.1.3.tgz#dc97502f5722e888467b3fa2297a7b1ff47df074"
@@ -4306,9 +4312,9 @@ rc@~1.1.6:
     minimist "^1.2.0"
     strip-json-comments "~1.0.4"
 
-react-addons-test-utils@^15.2.0:
-  version "15.4.2"
-  resolved "https://registry.yarnpkg.com/react-addons-test-utils/-/react-addons-test-utils-15.4.2.tgz#93bcaa718fcae7360d42e8fb1c09756cc36302a2"
+react-addons-test-utils@^15.5.1:
+  version "15.5.1"
+  resolved "https://registry.yarnpkg.com/react-addons-test-utils/-/react-addons-test-utils-15.5.1.tgz#e0d258cda2a122ad0dff69f838260d0c3958f5f7"
   dependencies:
     fbjs "^0.8.4"
     object-assign "^4.1.0"
@@ -4317,13 +4323,14 @@ react-deep-force-update@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/react-deep-force-update/-/react-deep-force-update-1.0.1.tgz#f911b5be1d2a6fe387507dd6e9a767aa2924b4c7"
 
-react-dom@^15.2.0:
-  version "15.4.2"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.4.2.tgz#015363f05b0a1fd52ae9efdd3a0060d90695208f"
+react-dom@^15.5.4:
+  version "15.5.4"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.5.4.tgz#ba0c28786fd52ed7e4f2135fe0288d462aef93da"
   dependencies:
-    fbjs "^0.8.1"
+    fbjs "^0.8.9"
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
+    prop-types "~15.5.7"
 
 react-hot-api@^0.4.5:
   version "0.4.7"
@@ -4354,13 +4361,14 @@ react-transform-hmr@^1.0.3:
     global "^4.3.0"
     react-proxy "^1.1.7"
 
-react@^15.2.0:
-  version "15.4.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-15.4.2.tgz#41f7991b26185392ba9bae96c8889e7e018397ef"
+react@^15.5.4:
+  version "15.5.4"
+  resolved "https://registry.yarnpkg.com/react/-/react-15.5.4.tgz#fa83eb01506ab237cdc1c8c3b1cea8de012bf047"
   dependencies:
-    fbjs "^0.8.4"
+    fbjs "^0.8.9"
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
+    prop-types "^15.5.7"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
This removes warning `Warning: Accessing PropTypes via the main React package is deprecated.`. 
Facebook moved PropTypes from package React to prop-types starting in v15.5 as stated [here](https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html).