### PR TITLE
add export for getRowProps and getColumnProps

### DIFF
--- a/react-flexbox-grid.d.ts
+++ b/react-flexbox-grid.d.ts
@@ -57,6 +57,9 @@ declare namespace __ReactFlexboxGrid {
   export class Col extends Component<ColProps, {}> {
 
   }
+    
+  export const getRowProps: (props: any) => any;
+  export const getColumnProps: (props: any) => any;
 }
 
 export = __ReactFlexboxGrid;


### PR DESCRIPTION
Error:(1, 19) TS2305: Module '"/node_modules/react-flexbox-grid/react-flexbox-grid"' has no exported member 'getRowProps'.
Error:(1, 32) TS2305: Module '"/node_modules/react-flexbox-grid/react-flexbox-grid"' has no exported member 'getColumnProps'.