### PR TITLE
Remove "babel-preset-es2015"

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,5 @@
 {
   "presets": [
-    "es2015",
     "stage-1",
     "react"
   ]

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "babel-plugin-react-transform": "^2.0.0",
     "babel-polyfill": "^6.23.0",
     "babel-preset-env": "^1.4.0",
-    "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-1": "^6.24.1",
     "cpx": "^1.2.1",


### PR DESCRIPTION
**"babel-preset-es2015"** is deprecated because **"babel-preset-env"** is exactly the same ([@babel/preset-env](https://github.com/babel/babel/tree/master/packages/babel-preset-env)).