### PR TITLE
Move to flexboxgrid2 7.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "react-component"
   ],
   "dependencies": {
-    "flexboxgrid2": "^7.0.0-alpha7",
+    "flexboxgrid2": "^7.2.0",
     "prop-types": "^15.5.8"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2173,9 +2173,9 @@ flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
 
-flexboxgrid2@^7.0.0-alpha7:
-  version "7.0.0-alpha7"
-  resolved "https://registry.yarnpkg.com/flexboxgrid2/-/flexboxgrid2-7.0.0-alpha7.tgz#758f16b40506439cb0b727de085058f2e53523a1"
+flexboxgrid2@^7.2.0:
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/flexboxgrid2/-/flexboxgrid2-7.2.1.tgz#3ffb9661ca5a9e96468eae648f8caf279bd0b2a4"
   dependencies:
     normalize.css "^7.0.0"
 


### PR DESCRIPTION
Stick with fresh version of flexboxgrid2. With some critical fixes. For example discussed in #145 